### PR TITLE
Add model ID fetcher

### DIFF
--- a/app/api/model/search/route.ts
+++ b/app/api/model/search/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { tamsSDK } from '@/service/tams'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const name = searchParams.get('name')
+  if (!name) {
+    return NextResponse.json({ message: 'name is required' }, { status: 400 })
+  }
+
+  try {
+    // attempt to search model by name using TAMS SDK
+    // the exact API may vary; this is a best-effort implementation
+    const resp: any = await (tamsSDK as any).v1.tamsApiV1ServiceListSdModels({
+      name,
+      page: 1,
+      pageSize: 10,
+    })
+    const models = resp?.data?.sdModels || []
+    const match = models.find((m: any) => m.name === name)
+    if (!match) {
+      return NextResponse.json({ message: 'Model not found' }, { status: 404 })
+    }
+    return NextResponse.json({ id: match.id })
+  } catch (err) {
+    console.error('model fetch failed', err)
+    return NextResponse.json({ message: 'Failed to fetch model id' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- allow fetching model ID via `/api/model/search`
- add `handleFetchModelId` and new input/button to get model IDs on the page

## Testing
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419d7634b4832a956d0246b7f5ba3c